### PR TITLE
Fixed doubled brace introduced in 9771f4e

### DIFF
--- a/BreadWallet/BRPeerManager.m
+++ b/BreadWallet/BRPeerManager.m
@@ -75,9 +75,6 @@ static const char *dns_seeds[] = {
     "52.183.103.9", "138.91.245.174", "13.82.55.134", "66.228.56.115"
 };
 
-};
-
-
 @interface BRPeerManager ()
 
 @property (nonatomic, strong) NSMutableOrderedSet *peers;


### PR DESCRIPTION
While un-commenting the DNS seeds, a second "};" was added in https://github.com/dgbholdings/digibyteios/commit/9771f4ed5647b71382fc6ef65040933ee0c55d88